### PR TITLE
Add time dependency Dockerfile for benchmark running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /octopus
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libboost_* /usr/lib/x86_64-linux-gnu/
 
-RUN apt-get update && apt-get install -y --no-install-recommends cpp
+RUN apt-get update && apt-get install -y --no-install-recommends cpp time
 
 COPY . /octopus
 


### PR DESCRIPTION
# Pull Request

## Description

Adds a missing runtime dependency for the timing of benchmarks by the benchmark runner script to the Dockerfile and thus the Docker image.
